### PR TITLE
Fix max_ngrams example to cast to int

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ from hyperopt import hp
 from hyperopt.pyll.base import scope
 
 search_space = {
-    "epochs": hp.qloguniform("epochs", 0, 4, 2),
+    'epochs': hp.qloguniform('epochs', 0, 4, 2),
     'max_df': hp.uniform('max_df', 1, 2),
     'max_ngrams': scope.int(hp.quniform('max_ngram', 3, 9, 1))
     }

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ You need to define a search space in the `nlu_hyperopt/space.py` file.
 
 ```
 from hyperopt import hp
+from hyperopt.pyll.base import scope
 
 search_space = {
-    'epochs': hp.qloguniform('epochs', 0, 4, 2),
-    'max_df': hp.uniform('max_df', 0.01, 1.0),
-    'max_ngrams': hp.quniform('max_ngram', 3, 9, 1)
+    "epochs": hp.qloguniform("epochs", 0, 4, 2),
+    'max_df': hp.uniform('max_df', 1, 2),
+    'max_ngrams': scope.int(hp.quniform('max_ngram', 3, 9, 1))
+    }
 }
 ```
 

--- a/data/template_config.yml
+++ b/data/template_config.yml
@@ -5,13 +5,5 @@ language: en
 pipeline:
 - name: "WhitespaceTokenizer"
 - name: "CountVectorsFeaturizer"
-  analyzer: char_wb
-  max_df: {max_df}
-  min_ngram: 1
-  max_ngram: {max_ngrams} 
 - name: "DIETClassifier"
   epochs: {epochs}
-- name: "ResponseSelector"
-  epochs: 200
-- name: RegexFeaturizer
-- name: EntitySynonymMapper

--- a/data/template_config.yml
+++ b/data/template_config.yml
@@ -1,10 +1,17 @@
 # This file contains your NLU pipeline configuration.
 # Replace parameters which you want to optimize with their name in 
 # curly brackets, e.g. `"epochs": 100` becomes `"epochs": {epochs}`.
-
 language: en
 pipeline:
 - name: "WhitespaceTokenizer"
 - name: "CountVectorsFeaturizer"
+  analyzer: char_wb
+  max_df: {max_df}
+  min_ngram: 1
+  max_ngram: {max_ngrams} 
 - name: "DIETClassifier"
   epochs: {epochs}
+- name: "ResponseSelector"
+  epochs: 200
+- name: RegexFeaturizer
+- name: EntitySynonymMapper

--- a/nlu_hyperopt/space.py
+++ b/nlu_hyperopt/space.py
@@ -4,7 +4,7 @@ from hyperopt import hp
 # from hyperopt.pyll.base import scope
 
 # search_space = {
-#     "epochs": hp.qloguniform("epochs", 0, 4, 2),
+#     'epochs': hp.qloguniform('epochs', 0, 4, 2),
 #     'max_df': hp.uniform('max_df', 1, 2),
 #     'max_ngrams': scope.int(hp.quniform('max_ngram', 3, 9, 1))
 #     }

--- a/nlu_hyperopt/space.py
+++ b/nlu_hyperopt/space.py
@@ -1,11 +1,13 @@
 from hyperopt import hp
 
 # Define the search space here, e.g.
+# from hyperopt.pyll.base import scope
+
 # search_space = {
-#     'epochs': hp.qloguniform('epochs', 0, 4, 2),
-#     'max_df': hp.uniform('max_df', 0.01, 1.0),
-#     'max_ngrams': hp.quniform('max_ngram', 3, 9, 1)
-# }
+#     "epochs": hp.qloguniform("epochs", 0, 4, 2),
+#     'max_df': hp.uniform('max_df', 1, 2),
+#     'max_ngrams': scope.int(hp.quniform('max_ngram', 3, 9, 1))
+#     }
 
 # Default search space: Try different numbers of training epochs.
 search_space = {"epochs": hp.qloguniform("epochs", 0, 4, 2)}


### PR DESCRIPTION
fixes https://github.com/RasaHQ/nlu-hyperopt/issues/12
In examples using `max_ngrams`, explicitly cast the type to `int`, since hyperopt has a bug https://github.com/hyperopt/hyperopt/issues/508 that means it gets re-cast to float regardless of how it is input. 